### PR TITLE
Text is actually a sub-class of String. Fixes #6

### DIFF
--- a/lib/text.rb
+++ b/lib/text.rb
@@ -1,11 +1,4 @@
 # encoding: utf-8
 
-class Text
-  def initialize(text)
-    @text = text
-  end
-  
-  def to_s
-    @text
-  end
+class Text < String
 end


### PR DESCRIPTION
Text had too much boilerplate code. Made it simple, as well as future-proof.

Text must be thought of as a subclass of string, as we are only interested in `new` and `to_s` methods.
